### PR TITLE
correct flask-admin url

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,7 +703,7 @@ A curated list of awesome Python frameworks, libraries and software. Inspired by
 * [Grappelli](http://grappelliproject.com) – A jazzy skin for the Django Admin-Interface.
 * [django-suit](http://djangosuit.com/) - Alternative Django Admin-Interface (free only for Non-commercial use).
 * [django-xadmin](https://github.com/sshwsfc/django-xadmin) - Drop-in replacement of Django admin comes with lots of goodies.
-* [flask-admin](https://github.com/mrjoes/flask-admin) - Simple and extensible administrative interface framework for Flask.
+* [flask-admin](https://github.com/flask-admin/flask-admin) - Simple and extensible administrative interface framework for Flask.
 * [flower](https://github.com/mher/flower) - Real-time monitor and web admin for Celery.
 
 ## Static Site Generator


### PR DESCRIPTION
Flask-admin moved from mrjoes/flask-admin to a new organization (flask-admin/flask-admin). This pull request corrects the URL.
